### PR TITLE
Bumps [ws](https://github.com/websockets/ws), [engine.io](https://git…

### DIFF
--- a/src/example-voting-app/result/package-lock.json
+++ b/src/example-voting-app/result/package-lock.json
@@ -217,9 +217,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.2.tgz",
-      "integrity": "sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
       "dependencies": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -230,7 +230,7 @@
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0"
+        "ws": "~8.17.1"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -850,12 +850,34 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-      "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
       "dependencies": {
-        "ws": "~8.11.0"
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
       }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
@@ -981,15 +1003,15 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -1165,9 +1187,9 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
     },
     "engine.io": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.2.tgz",
-      "integrity": "sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
       "requires": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -1178,7 +1200,7 @@
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0"
+        "ws": "~8.17.1"
       },
       "dependencies": {
         "debug": {
@@ -1652,11 +1674,27 @@
       }
     },
     "socket.io-adapter": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-      "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
       "requires": {
-        "ws": "~8.11.0"
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+          "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "socket.io-parser": {
@@ -1728,9 +1766,9 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "requires": {}
     },
     "xtend": {


### PR DESCRIPTION
Bumps [ws](https://github.com/websockets/ws), [engine.io](https://github.com/socketio/engine.io) and [socket.io-adapter](https://github.com/socketio/socket.io-adapter). These dependencies needed to be updated together.
Updates `ws` from 8.11.0 to 8.17.1
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/websockets/ws/releases">ws's releases</a>.</em></p>
<blockquote>
<h2>8.17.1</h2>
<h1>Bug fixes</h1>
<ul>
<li>Fixed a DoS vulnerability (<a href="https://redirect.github.com/websockets/ws/issues/2231">#2231</a>).</li>
</ul>
<p>A request with a number of headers exceeding the[<code>server.maxHeadersCount</code>][]
threshold could be used to crash a ws server.</p>
<pre lang="js"><code>const http = require('http');
const WebSocket = require('ws');
<p>const wss = new WebSocket.Server({ port: 0 }, function () {
const chars = &quot;!#$%&amp;'*+-.0123456789abcdefghijklmnopqrstuvwxyz^_`|~&quot;.split('');
const headers = {};
let count = 0;</p>
<p>for (let i = 0; i &lt; chars.length; i++) {
if (count === 2000) break;</p>
<pre><code>for (let j = 0; j &amp;lt; chars.length; j++) {
  const key = chars[i] + chars[j];
  headers[key] = 'x';

  if (++count === 2000) break;
}
</code></pre>
<p>}</p>
<p>headers.Connection = 'Upgrade';
headers.Upgrade = 'websocket';
headers['Sec-WebSocket-Key'] = 'dGhlIHNhbXBsZSBub25jZQ==';
headers['Sec-WebSocket-Version'] = '13';</p>
<p>const request = http.request({
headers: headers,
host: '127.0.0.1',
port: wss.address().port
});</p>
<p>request.end();
});
</code></pre></p>
<p>The vulnerability was reported by <a href="https://github.com/rrlapointe">Ryan LaPointe</a> in <a href="https://redirect.github.com/websockets/ws/issues/2230">websockets/ws#2230</a>.</p>
<p>In vulnerable versions of ws, the issue can be mitigated in the following ways:</p>
<ol>
<li>Reduce the maximum allowed length of the request headers using the
[<code>--max-http-header-size=size</code>][] and/or the [<code>maxHeaderSize</code>][] options so
that no more headers than the <code>server.maxHeadersCount</code> limit can be sent.</li>
</ol>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/websockets/ws/commit/3c56601092872f7d7566989f0e379271afd0e4a1"><code>3c56601</code></a> [dist] 8.17.1</li>
<li><a href="https://github.com/websockets/ws/commit/e55e5106f10fcbaac37cfa89759e4cc0d073a52c"><code>e55e510</code></a> [security] Fix crash when the Upgrade header cannot be read (<a href="https://redirect.github.com/websockets/ws/issues/2231">#2231</a>)</li>
<li><a href="https://github.com/websockets/ws/commit/6a00029edd924499f892aed8003cef1fa724cfe5"><code>6a00029</code></a> [test] Increase code coverage</li>
<li><a href="https://github.com/websockets/ws/commit/ddfe4a804d79e7788ab136290e609f91cf68423f"><code>ddfe4a8</code></a> [perf] Reduce the amount of <code>crypto.randomFillSync()</code> calls</li>
<li><a href="https://github.com/websockets/ws/commit/b73b11828d166e9692a9bffe9c01a7e93bab04a8"><code>b73b118</code></a> [dist] 8.17.0</li>
<li><a href="https://github.com/websockets/ws/commit/29694a5905fa703e86667928e6bacac397469471"><code>29694a5</code></a> [test] Use the <code>highWaterMark</code> variable</li>
<li><a href="https://github.com/websockets/ws/commit/934c9d6b938b93c045cb13e5f7c19c27a8dd925a"><code>934c9d6</code></a> [ci] Test on node 22</li>
<li><a href="https://github.com/websockets/ws/commit/1817bac06e1204bfb578b8b3f4bafd0fa09623d0"><code>1817bac</code></a> [ci] Do not test on node 21</li>
<li><a href="https://github.com/websockets/ws/commit/96c9b3deddf56cacb2d756aaa918071e03cdbc42"><code>96c9b3d</code></a> [major] Flip the default value of <code>allowSynchronousEvents</code> (<a href="https://redirect.github.com/websockets/ws/issues/2221">#2221</a>)</li>
<li><a href="https://github.com/websockets/ws/commit/e5f32c7e1e6d3d19cd4a1fdec84890e154db30c1"><code>e5f32c7</code></a> [fix] Emit at most one event per event loop iteration (<a href="https://redirect.github.com/websockets/ws/issues/2218">#2218</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/websockets/ws/compare/8.11.0...8.17.1">compare view</a></li>
</ul>
</details>
<br />

Updates `engine.io` from 6.5.2 to 6.5.5
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/socketio/engine.io/releases">engine.io's releases</a>.</em></p>
<blockquote>
<h2>6.5.5</h2>
<p>This release contains a bump of the <code>ws</code> dependency, which includes an important <a href="https://github.com/websockets/ws/commit/e55e5106f10fcbaac37cfa89759e4cc0d073a52c">security fix</a>.</p>
<p>Advisory: <a href="https://github.com/advisories/GHSA-3h5v-q93c-6h6q">https://github.com/advisories/GHSA-3h5v-q93c-6h6q</a></p>
<h3>Bug Fixes</h3>
<ul>
<li><strong>types:</strong> make socket.request writable (<a href="https://redirect.github.com/socketio/engine.io/issues/697">#697</a>) (<a href="https://github.com/socketio/engine.io/commit/0efa04b5841816d18b0c6ebf7c5f592f8382978a">0efa04b</a>)</li>
</ul>
<h4>Links</h4>
<ul>
<li>Diff: <a href="https://github.com/socketio/engine.io/compare/6.5.4...6.5.5">https://github.com/socketio/engine.io/compare/6.5.4...6.5.5</a></li>
<li>Client release: -</li>
<li><a href="https://github.com/websockets/ws/releases/tag/8.17.1"><code>ws@~8.17.1</code></a> (<a href="https://github.com/websockets/ws/compare/8.11.0...8.17.1">diff</a>)</li>
</ul>
<h2>6.5.4</h2>
<p>This release contains some minor changes which should improve the memory usage of the server, notably <a href="https://github.com/socketio/engine.io/commit/f27a6c35017e4eb37546949f754e09933102837a">this</a>.</p>
<h4>Links</h4>
<ul>
<li>Diff: <a href="https://github.com/socketio/engine.io/compare/6.5.3...6.5.4">https://github.com/socketio/engine.io/compare/6.5.3...6.5.4</a></li>
<li>Client release: -</li>
<li>ws version: <a href="https://github.com/websockets/ws/releases/tag/8.11.0">~8.11.0</a> (no change)</li>
</ul>
<h2>6.5.3</h2>
<h3>Bug Fixes</h3>
<ul>
<li>improve compatibility with node16 module resolution (<a href="https://redirect.github.com/socketio/engine.io/issues/689">#689</a>) (<a href="https://github.com/socketio/engine.io/commit/c6bf8c0f571aad7a5917f43860c8c3d74a9b429b">c6bf8c0</a>)</li>
<li><strong>webtransport:</strong> properly handle abruptly closed connections (<a href="https://github.com/socketio/engine.io/commit/ff1c8615483bab25acc9cf04fb40339b0bd78812">ff1c861</a>)</li>
</ul>
<h4>Links</h4>
<ul>
<li>Diff: <a href="https://github.com/socketio/engine.io/compare/6.5.2...6.5.3">https://github.com/socketio/engine.io/compare/6.5.2...6.5.3</a></li>
<li>Client release: -</li>
<li>ws version: <a href="https://github.com/websockets/ws/releases/tag/8.11.0">~8.11.0</a> (no change)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/socketio/engine.io/blob/main/CHANGELOG.md">engine.io's changelog</a>.</em></p>
<blockquote>
<h2><a href="https://github.com/socketio/engine.io/compare/6.5.4...6.5.5">6.5.5</a> (2024-06-18)</h2>
<p>This release contains a bump of the <code>ws</code> dependency, which includes an important <a href="https://github.com/websockets/ws/commit/e55e5106f10fcbaac37cfa89759e4cc0d073a52c">security fix</a>.</p>
<p>Advisory: <a href="https://github.com/advisories/GHSA-3h5v-q93c-6h6q">https://github.com/advisories/GHSA-3h5v-q93c-6h6q</a></p>
<h3>Bug Fixes</h3>
<ul>
<li><strong>types:</strong> make socket.request writable (<a href="https://redirect.github.com/socketio/engine.io/issues/697">#697</a>) (<a href="https://github.com/socketio/engine.io/commit/0efa04b5841816d18b0c6ebf7c5f592f8382978a">0efa04b</a>)</li>
</ul>
<h3>Dependencies</h3>
<ul>
<li><a href="https://github.com/websockets/ws/releases/tag/8.17.1"><code>ws@~8.17.1</code></a> (<a href="https://github.com/websockets/ws/compare/8.11.0...8.17.1">diff</a>)</li>
</ul>
<h2><a href="https://github.com/socketio/engine.io/compare/3.6.1...3.6.2">3.6.2</a> (2024-06-18)</h2>
<p>This release contains a bump of the <code>ws</code> dependency, which includes an important <a href="https://github.com/websockets/ws/commit/e55e5106f10fcbaac37cfa89759e4cc0d073a52c">security fix</a>.</p>
<p>Advisory: <a href="https://github.com/advisories/GHSA-3h5v-q93c-6h6q">https://github.com/advisories/GHSA-3h5v-q93c-6h6q</a></p>
<h3>Dependencies</h3>
<ul>
<li><a href="https://github.com/websockets/ws/releases/tag/7.5.10"><code>ws@~7.5.10</code></a> (<a href="https://github.com/websockets/ws/compare/7.4.2...7.5.10">diff</a>)</li>
</ul>
<h2><a href="https://github.com/socketio/engine.io/compare/6.5.3...6.5.4">6.5.4</a> (2023-11-09)</h2>
<p>This release contains some minor changes which should improve the memory usage of the server, notably <a href="https://github.com/socketio/engine.io/commit/f27a6c35017e4eb37546949f754e09933102837a">this</a>.</p>
<h3>Dependencies</h3>
<ul>
<li><a href="https://github.com/websockets/ws/releases/tag/8.11.0"><code>ws@~8.11.0</code></a> (no change)</li>
</ul>
<h2><a href="https://github.com/socketio/engine.io/compare/6.5.2...6.5.3">6.5.3</a> (2023-10-06)</h2>
<h3>Bug Fixes</h3>
<ul>
<li>improve compatibility with node16 module resolution (<a href="https://redirect.github.com/socketio/engine.io/issues/689">#689</a>) (<a href="https://github.com/socketio/engine.io/commit/c6bf8c0f571aad7a5917f43860c8c3d74a9b429b">c6bf8c0</a>)</li>
<li><strong>webtransport:</strong> properly handle abruptly closed connections (<a href="https://github.com/socketio/engine.io/commit/ff1c8615483bab25acc9cf04fb40339b0bd78812">ff1c861</a>)</li>
</ul>
<h3>Dependencies</h3>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/socketio/engine.io/commit/0cb977ab69134c4d040a2135d429c12724d52ae1"><code>0cb977a</code></a> chore(release): 6.5.5</li>
<li><a href="https://github.com/socketio/engine.io/commit/adaa2079c4198b5f51e61d61aa68893db9247cc0"><code>adaa207</code></a> chore(deps): bump ws from 8.11.0 to 8.17.1 (<a href="https://redirect.github.com/socketio/engine.io/issues/702">#702</a>)</li>
<li><a href="https://github.com/socketio/engine.io/commit/0efa04b5841816d18b0c6ebf7c5f592f8382978a"><code>0efa04b</code></a> fix(types): make socket.request writable (<a href="https://redirect.github.com/socketio/engine.io/issues/697">#697</a>)</li>
<li><a href="https://github.com/socketio/engine.io/commit/ff0fbfb61f2509ef302870cfd993344c1d035e7d"><code>ff0fbfb</code></a> chore(release): 6.5.4</li>
<li><a href="https://github.com/socketio/engine.io/commit/09acb177a6e3bceea06643d403d9c99782a2a3d5"><code>09acb17</code></a> ci: add Node.js 20 in the test matrix</li>
<li><a href="https://github.com/socketio/engine.io/commit/39937f8f4d8b5b3c48d118f66dbe59809cff2940"><code>39937f8</code></a> refactor: minor cleanups</li>
<li><a href="https://github.com/socketio/engine.io/commit/43c1c1c1e2a366317fe2684f6b31dd71ba7458a5"><code>43c1c1c</code></a> refactor: simplify code</li>
<li><a href="https://github.com/socketio/engine.io/commit/3b5e79ef7942226d0c06b6e99872f138e402bf55"><code>3b5e79e</code></a> refactor: remove useless references</li>
<li><a href="https://github.com/socketio/engine.io/commit/f27a6c35017e4eb37546949f754e09933102837a"><code>f27a6c3</code></a> refactor: remove useless reference</li>
<li><a href="https://github.com/socketio/engine.io/commit/2da559a8fa8376a835bfaedfb13ef075414af306"><code>2da559a</code></a> chore(release): 6.5.3</li>
<li>Additional commits viewable in <a href="https://github.com/socketio/engine.io/compare/6.5.2...6.5.5">compare view</a></li>
</ul>
</details>
<br />

Updates `socket.io-adapter` from 2.5.2 to 2.5.5
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/socketio/socket.io-adapter/releases">socket.io-adapter's releases</a>.</em></p>
<blockquote>
<h2>2.5.4</h2>
<h3>Bug Fixes</h3>
<ul>
<li>ensure the order of the commands (<a href="https://github.com/socketio/socket.io-adapter/commit/a13f35f0e6b85bbba07f99ee2440e914f1429d83">a13f35f</a>)</li>
<li><strong>types:</strong> ensure compatibility with TypeScript &lt; 4.5 (<a href="https://github.com/socketio/socket.io-adapter/commit/ca397f3afe06ed9390db52b70a506a9721e091d8">ca397f3</a>)</li>
</ul>
<h3>Links</h3>
<ul>
<li>Diff: <a href="https://github.com/socketio/socket.io-adapter/compare/2.5.3...2.5.4">https://github.com/socketio/socket.io-adapter/compare/2.5.3...2.5.4</a></li>
</ul>
<h2>2.5.3</h2>
<p>Two abstract classes were imported from the <a href="https://github.com/socketio/socket.io-redis-adapter/blob/bd32763043a2eb79a21dffd8820f20e598348adf/lib/cluster-adapter.ts">Redis adapter repository</a>:</p>
<ul>
<li>the <code>ClusterAdapter</code> class, which manages the messages sent between the server instances of the cluster</li>
<li>the <code>ClusterAdapterWithHeartbeat</code> class, which extends the <code>ClusterAdapter</code> and adds a heartbeat mechanism in order to check the healthiness of the other instances</li>
</ul>
<p>Other adapters can then just extend those classes and only have to implement the pub/sub mechanism (and not the internal chit-chat protocol):</p>
<pre lang="js"><code>class MyAdapter extends ClusterAdapterWithHeartbeat {
  constructor(nsp, pubSub, opts) {
    super(nsp, opts);
    this.pubSub = pubSub;
    pubSub.subscribe(&quot;main-channel&quot;, (message) =&gt; this.onMessage(message));
    pubSub.subscribe(&quot;specific-channel#&quot; + this.uid, (response) =&gt; this.onResponse(response));
  }
<p>doPublish(message) {<br />
return this.pubSub.publish(&quot;main-channel&quot;, message);<br />
}</p>
<p>doPublishResponse(requesterUid, response) {<br />
return this.pubSub.publish(&quot;specific-channel#&quot; + requesterUid, response);<br />
}<br />
}<br />
</code></pre></p>
<p>Besides, the number of &quot;timeout reached: only x responses received out of y&quot; errors (which can happen when a server instance leaves the cluster) should be greatly reduced by <a href="https://github.com/socketio/socket.io-adapter/commit/0e23ff0cc671e3186510f7cfb8a4c1147457296f">this commit</a>.</p>
<h3>Bug Fixes</h3>
<ul>
<li><strong>cluster:</strong> fix count in fetchSockets() method (<a href="https://github.com/socketio/socket.io-adapter/commit/80af4e939c9caf89b0234ba1e676a3887c8d0ce6">80af4e9</a>)</li>
<li><strong>cluster:</strong> notify the other nodes when closing (<a href="https://github.com/socketio/socket.io-adapter/commit/0e23ff0cc671e3186510f7cfb8a4c1147457296f">0e23ff0</a>)</li>
</ul>
<h3>Performance Improvements</h3>
<ul>
<li><strong>cluster:</strong> use timer.refresh() (<a href="https://github.com/socketio/socket.io-adapter/commit/d99a71b5588f53f0b181eee989ab2ac939f965db">d99a71b</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/socketio/socket.io-adapter/blob/main/CHANGELOG.md">socket.io-adapter's changelog</a>.</em></p>
<blockquote>
<h2><a href="https://github.com/socketio/socket.io-adapter/compare/2.5.4...2.5.5">2.5.5</a> (2024-06-18)</h2>
<p>This release contains a bump of the <code>ws</code> dependency, which includes an important <a href="https://github.com/websockets/ws/commit/e55e5106f10fcbaac37cfa89759e4cc0d073a52c">security fix</a>.</p>
<p>Advisory: <a href="https://github.com/advisories/GHSA-3h5v-q93c-6h6q">https://github.com/advisories/GHSA-3h5v-q93c-6h6q</a></p>
<h2><a href="https://github.com/socketio/socket.io-adapter/compare/2.5.3...2.5.4">2.5.4</a> (2024-02-22)</h2>
<h3>Bug Fixes</h3>
<ul>
<li>ensure the order of the commands (<a href="https://github.com/socketio/socket.io-adapter/commit/a13f35f0e6b85bbba07f99ee2440e914f1429d83">a13f35f</a>)</li>
<li><strong>types:</strong> ensure compatibility with TypeScript &lt; 4.5 (<a href="https://github.com/socketio/socket.io-adapter/commit/ca397f3afe06ed9390db52b70a506a9721e091d8">ca397f3</a>)</li>
</ul>
<h2><a href="https://github.com/socketio/socket.io-adapter/compare/2.5.2...2.5.3">2.5.3</a> (2024-02-21)</h2>
<p>Two abstract classes were imported from the <a href="https://github.com/socketio/socket.io-redis-adapter/blob/bd32763043a2eb79a21dffd8820f20e598348adf/lib/cluster-adapter.ts">Redis adapter repository</a>:</p>
<ul>
<li>the <code>ClusterAdapter</code> class, which manages the messages sent between the server instances of the cluster</li>
<li>the <code>ClusterAdapterWithHeartbeat</code> class, which extends the <code>ClusterAdapter</code> and adds a heartbeat mechanism in order to check the healthiness of the other instances</li>
</ul>
<p>Other adapters can then just extend those classes and only have to implement the pub/sub mechanism (and not the internal chit-chat protocol):</p>
<pre lang="js"><code>class MyAdapter extends ClusterAdapterWithHeartbeat {
  constructor(nsp, pubSub, opts) {
    super(nsp, opts);
    this.pubSub = pubSub;
    pubSub.subscribe(&quot;main-channel&quot;, (message) =&gt; this.onMessage(message));
    pubSub.subscribe(&quot;specific-channel#&quot; + this.uid, (response) =&gt; this.onResponse(response));
  }
<p>doPublish(message) {<br />
return this.pubSub.publish(&quot;main-channel&quot;, message);<br />
}</p>
<p>doPublishResponse(requesterUid, response) {<br />
return this.pubSub.publish(&quot;specific-channel#&quot; + requesterUid, response);<br />
}<br />
}<br />
</code></pre></p>
<p>Besides, the number of &quot;timeout reached: only x responses received out of y&quot; errors (which can happen when a server instance leaves the cluster) should be greatly reduced by <a href="https://github.com/socketio/socket.io-adapter/commit/0e23ff0cc671e3186510f7cfb8a4c1147457296f">this commit</a>.</p>
<h3>Bug Fixes</h3>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/socketio/socket.io-adapter/commit/05a190a9dbf40226a1f8c0d21c0f7dc3718a297c"><code>05a190a</code></a> chore(release): 6.5.5</li>
<li><a href="https://github.com/socketio/socket.io-adapter/commit/93fe19019e1c0b82a41a15bd86acbac10634c60b"><code>93fe190</code></a> chore(deps): bump ws from 8.11.0 to 8.17.1 (<a href="https://redirect.github.com/socketio/socket.io-adapter/issues/93">#93</a>)</li>
<li><a href="https://github.com/socketio/socket.io-adapter/commit/5eae5a0b541b2d671b561e88029f8aa888cb33f9"><code>5eae5a0</code></a> chore(release): 2.5.4</li>
<li><a href="https://github.com/socketio/socket.io-adapter/commit/005d546767508227309b01c75a47c006ccb46f26"><code>005d546</code></a> ci: test with older TypeScript version</li>
<li><a href="https://github.com/socketio/socket.io-adapter/commit/a13f35f0e6b85bbba07f99ee2440e914f1429d83"><code>a13f35f</code></a> fix: ensure the order of the commands</li>
<li><a href="https://github.com/socketio/socket.io-adapter/commit/207c0dba1af9d929fb076b5bd60253adc778c98a"><code>207c0db</code></a> refactor: break circular dependency (2)</li>
<li><a href="https://github.com/socketio/socket.io-adapter/commit/abc93a9ac75e1dd0258349af10a0ad6e4617da5d"><code>abc93a9</code></a> refactor: break circular dependency (1)</li>
<li><a href="https://github.com/socketio/socket.io-adapter/commit/9d4c4a75a498e6766a06bffb02c0e5253b8d4efd"><code>9d4c4a7</code></a> refactor(cluster): export ClusterAdapterOptions and MessageType types</li>
<li><a href="https://github.com/socketio/socket.io-adapter/commit/ca397f3afe06ed9390db52b70a506a9721e091d8"><code>ca397f3</code></a> fix(types): ensure compatibility with TypeScript &lt; 4.5</li>
<li><a href="https://github.com/socketio/socket.io-adapter/commit/549156c064bd7abb6cb2ae0aadd508afe16d7c3d"><code>549156c</code></a> chore(release): 2.5.3</li>
<li>Additional commits viewable in <a href="https://github.com/socketio/socket.io-adapter/compare/2.5.2...2.5.5">compare view</a></li>
</ul>
</details>
<br />
